### PR TITLE
Update amap_location.dart fix not initialized errors

### DIFF
--- a/lib/amap_location.dart
+++ b/lib/amap_location.dart
@@ -23,6 +23,16 @@ class AMapLocationQualityReport {
   final double netUseTime;
 
   final String adviseMessage;
+  
+  AMapLocationQualityReport({
+    this.wifiAble,
+    this.gpsStatus,
+    this.gpsSatellites,
+    this.networkType,
+    this.netUseTime,
+    this.adviseMessage,
+  });
+
 }
 
 class AMapLocation {


### PR DESCRIPTION
fix:
Error: Final field 'wifiAble' is not initialized.
compiler message: Try to initialize the field in the declaration or in every constructor.
compiler message:   final bool wifiAble;
compiler message:              ^^^^^^^^
......