### PR TITLE
在iOS的配置文件中直接修改AMAP_KEY，无需修改代码。

### DIFF
--- a/ios/Classes/AmapLocationPlugin.m
+++ b/ios/Classes/AmapLocationPlugin.m
@@ -31,6 +31,10 @@ static NSDictionary* DesiredAccuracy = @{@"kCLLocationAccuracyBest":@(kCLLocatio
     AmapLocationPlugin* instance = [[AmapLocationPlugin alloc] init];
     instance.channel = channel;
     [registrar addMethodCallDelegate:instance channel:channel];
+    NSString *plistPath = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+    NSDictionary *data = [[NSDictionary alloc] initWithContentsOfFile:plistPath];
+     NSString * amapKey = [data objectForKey:@"AMAP_KEY"];
+    [AMapServices sharedServices].apiKey = amapKey;
 }
 
 


### PR DESCRIPTION
支持在Info.plist中配置AMAP_KEY，和安卓的配置风格统一，不再需要修改代码设置。